### PR TITLE
Explicitly extend entities from IdEntity

### DIFF
--- a/entities/src/main/java/org/n52/series/db/beans/parameter/ParameterFactory.java
+++ b/entities/src/main/java/org/n52/series/db/beans/parameter/ParameterFactory.java
@@ -116,8 +116,10 @@ public class ParameterFactory {
     /**
      * Creates a concrete ParameterEntity based on the type of the Entity and the Parameter
      *
-     * @param valueType type of the value
-     * @param entity    the entity
+     * @param valueType
+     *            type of the value
+     * @param entity
+     *            the entity
      * @return concrete class
      */
     public static ParameterEntity<?> from(Object entity, ValueType valueType) {
@@ -149,8 +151,10 @@ public class ParameterFactory {
     /**
      * Creates a concrete ParameterEntity based on the type of the Entity and the Parameter
      *
-     * @param valueType  type of the value
-     * @param entityType type of the entity
+     * @param valueType
+     *            type of the value
+     * @param entityType
+     *            type of the entity
      * @return concrete class
      */
     public static ParameterEntity<?> from(EntityType entityType, ValueType valueType) {
@@ -367,7 +371,6 @@ public class ParameterFactory {
     public enum EntityType {
         PHENOMENON, PROCEDURE, PLATFORM, DATASET, FEATURE, OBSERVATION, LOCATION, LICENSE, OBS_GROUP, PROJECT
     }
-
 
     public enum ValueType {
         BOOLEAN, TEXT, JSON, XML, COUNT, CATEGORY, QUANTITY, COMPLEX

--- a/entities/src/main/java/org/n52/series/db/beans/parameter/ParameterFactory.java
+++ b/entities/src/main/java/org/n52/series/db/beans/parameter/ParameterFactory.java
@@ -20,7 +20,6 @@ package org.n52.series.db.beans.parameter;
 import org.n52.series.db.beans.AbstractDatasetEntity;
 import org.n52.series.db.beans.AbstractFeatureEntity;
 import org.n52.series.db.beans.DataEntity;
-import org.n52.series.db.beans.DescribableEntity;
 import org.n52.series.db.beans.PhenomenonEntity;
 import org.n52.series.db.beans.PlatformEntity;
 import org.n52.series.db.beans.ProcedureEntity;

--- a/entities/src/main/java/org/n52/series/db/beans/sta/LicenseEntity.java
+++ b/entities/src/main/java/org/n52/series/db/beans/sta/LicenseEntity.java
@@ -19,6 +19,7 @@ package org.n52.series.db.beans.sta;
 
 import org.n52.series.db.beans.AbstractDatasetEntity;
 import org.n52.series.db.beans.HibernateRelations;
+import org.n52.series.db.beans.IdEntity;
 import org.n52.series.db.beans.parameter.ParameterEntity;
 import org.n52.series.db.beans.parameter.license.LicenseParameterEntity;
 
@@ -39,15 +40,13 @@ import java.util.Set;
 @Entity
 @SequenceGenerator(name = "license_seq", allocationSize = 1)
 @Table(name = "license")
-public class LicenseEntity implements HibernateRelations.HasId,
-                                      HibernateRelations.HasName,
-                                      HibernateRelations.HasAbstractDatasets,
-                                      HibernateRelations.HasStaIdentifier,
-                                      HibernateRelations.HasParameters {
+public class LicenseEntity extends IdEntity implements HibernateRelations.HasId, HibernateRelations.HasName,
+        HibernateRelations.HasAbstractDatasets, HibernateRelations.HasStaIdentifier, HibernateRelations.HasParameters {
 
     public static final String PROPERTY_DATASETS = "datasets";
     public static final String PROPERTY_DEFINITION = "definition";
     public static final String PROPERTY_LOGO = "logo";
+    private static final long serialVersionUID = 6159174609682812188L;
 
     @Id
     @Column(nullable = false, name = "license_id", unique = true)
@@ -74,14 +73,6 @@ public class LicenseEntity implements HibernateRelations.HasId,
 
     @OneToMany(mappedBy = LicenseParameterEntity.PROP_LICENSE, targetEntity = LicenseParameterEntity.class)
     private Set<ParameterEntity<?>> parameters;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getStaIdentifier() {
         return staIdentifier;

--- a/entities/src/main/java/org/n52/series/db/beans/sta/ObservationGroupEntity.java
+++ b/entities/src/main/java/org/n52/series/db/beans/sta/ObservationGroupEntity.java
@@ -18,6 +18,7 @@
 package org.n52.series.db.beans.sta;
 
 import org.n52.series.db.beans.HibernateRelations;
+import org.n52.series.db.beans.IdEntity;
 import org.n52.series.db.beans.parameter.ParameterEntity;
 import org.n52.series.db.beans.parameter.observationgroup.ObservationGroupParameterEntity;
 
@@ -39,11 +40,12 @@ import java.util.Set;
 @Entity
 @Table(name = "observationgroup")
 @SequenceGenerator(name = "observation_group_seq", allocationSize = 1)
-public class ObservationGroupEntity
+public class ObservationGroupEntity extends IdEntity
         implements HibernateRelations.HasId, HibernateRelations.HasName, HibernateRelations.HasStaIdentifier,
         HibernateRelations.HasDescription, HibernateRelations.IsProcessed, HibernateRelations.HasParameters {
 
     public static final String PROP_ENTITIES = "entities";
+    private static final long serialVersionUID = 3611419770138299218L;
 
     @Id
     @Column(nullable = false, unique = true)
@@ -74,16 +76,6 @@ public class ObservationGroupEntity
 
     @Transient
     private boolean processed;
-
-    @Override
-    public Long getId() {
-        return id;
-    }
-
-    @Override
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     @Override
     public String getName() {

--- a/entities/src/main/java/org/n52/series/db/beans/sta/ObservationRelationEntity.java
+++ b/entities/src/main/java/org/n52/series/db/beans/sta/ObservationRelationEntity.java
@@ -18,6 +18,7 @@
 package org.n52.series.db.beans.sta;
 
 import org.n52.series.db.beans.HibernateRelations;
+import org.n52.series.db.beans.IdEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -35,11 +36,13 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "observationrelation")
 @SequenceGenerator(name = "observation_rel_seq", allocationSize = 1)
-public class ObservationRelationEntity implements HibernateRelations.HasId, HibernateRelations.HasStaIdentifier {
+public class ObservationRelationEntity extends IdEntity
+        implements HibernateRelations.HasId, HibernateRelations.HasStaIdentifier {
 
     public static final String PROPERTY_GROUP = "group";
     public static final String PROPERTY_OBSERVATION = "observation";
     public static final String PROPERTY_TYPE = "type";
+    private static final long serialVersionUID = -5523688573276493324L;
 
     @Id
     @Column(nullable = false, unique = true)
@@ -64,14 +67,6 @@ public class ObservationRelationEntity implements HibernateRelations.HasId, Hibe
 
     @ManyToOne(targetEntity = ObservationGroupEntity.class, optional = false)
     private ObservationGroupEntity group;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     @Override
     public String getStaIdentifier() {

--- a/entities/src/main/java/org/n52/series/db/beans/sta/PartyEntity.java
+++ b/entities/src/main/java/org/n52/series/db/beans/sta/PartyEntity.java
@@ -48,6 +48,7 @@ package org.n52.series.db.beans.sta;
 
 import org.n52.series.db.beans.AbstractDatasetEntity;
 import org.n52.series.db.beans.HibernateRelations;
+import org.n52.series.db.beans.IdEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -67,7 +68,7 @@ import java.util.Set;
 @Entity
 @SequenceGenerator(name = "cs_observation_seq", allocationSize = 1)
 @Table(name = "party")
-public class PartyEntity implements HibernateRelations.HasId, HibernateRelations.HasAbstractDatasets,
+public class PartyEntity extends IdEntity implements HibernateRelations.HasId, HibernateRelations.HasAbstractDatasets,
         HibernateRelations.HasStaIdentifier {
 
     public enum Role {
@@ -77,6 +78,7 @@ public class PartyEntity implements HibernateRelations.HasId, HibernateRelations
     public static final String PROPERTY_DATASTREAMS = "datasets";
     public static final String PROPERTY_NICKNAME = "nickname";
     public static final String PROPERTY_ROLE = "role";
+    private static final long serialVersionUID = 5875256537419920242L;
 
     @Id
     @Column(nullable = false, name = "party_id", unique = true)

--- a/entities/src/main/java/org/n52/series/db/beans/sta/ProjectEntity.java
+++ b/entities/src/main/java/org/n52/series/db/beans/sta/ProjectEntity.java
@@ -18,6 +18,7 @@ package org.n52.series.db.beans.sta;
 
 import org.n52.series.db.beans.AbstractDatasetEntity;
 import org.n52.series.db.beans.HibernateRelations;
+import org.n52.series.db.beans.IdEntity;
 import org.n52.series.db.beans.parameter.ParameterEntity;
 import org.n52.series.db.beans.parameter.project.ProjectParameterEntity;
 
@@ -39,7 +40,7 @@ import java.util.Set;
 @Entity
 @SequenceGenerator(name = "project_seq", allocationSize = 1)
 @Table(name = "project")
-public class ProjectEntity
+public class ProjectEntity extends IdEntity
         implements HibernateRelations.HasId, HibernateRelations.HasName, HibernateRelations.HasDescription,
         HibernateRelations.HasAbstractDatasets, HibernateRelations.HasStaIdentifier, HibernateRelations.HasParameters {
 
@@ -50,6 +51,7 @@ public class ProjectEntity
     public static final String PROPERTY_PRIVACY_POLICY = "privacyPolicy";
     public static final String PROPERTY_TERMS_OF_USE = "termsOfUse";
     public static final String PROPERTY_CLASSIFICATION = "classification";
+    private static final long serialVersionUID = 1050625647937315126L;
 
     @Id
     @Column(nullable = false, name = "project_id", unique = true)
@@ -92,14 +94,6 @@ public class ProjectEntity
     @OneToMany(mappedBy = ProjectParameterEntity.PROP_PROJECT, targetEntity = ProjectParameterEntity.class)
     private Set<ParameterEntity<?>> parameters;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getStaIdentifier() {
         return staIdentifier;
     }
@@ -125,19 +119,27 @@ public class ProjectEntity
     }
 
     public Date getRuntimeStart() {
-        return runtimeStart;
+        return runtimeStart != null
+        		? new Date(runtimeStart.getTime())
+				: null;
     }
 
     public void setRuntimeStart(Date runtimeStart) {
-        this.runtimeStart = runtimeStart;
+        this.runtimeStart = runtimeStart != null
+        		? new Date(runtimeStart.getTime())
+				: null;
     }
 
     public Date getRuntimeEnd() {
-        return runtimeEnd;
+        return runtimeEnd != null
+        		? new Date(runtimeEnd.getTime())
+				: null;
     }
 
     public void setRuntimeEnd(Date runtimeEnd) {
-        this.runtimeEnd = runtimeEnd;
+        this.runtimeEnd = runtimeEnd != null
+        		? new Date(runtimeEnd.getTime())
+        		: null;
     }
 
     public String getUrl() {

--- a/entities/src/main/java/org/n52/series/db/beans/sta/ProjectEntity.java
+++ b/entities/src/main/java/org/n52/series/db/beans/sta/ProjectEntity.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.n52.series.db.beans.sta;
 
 import org.n52.series.db.beans.AbstractDatasetEntity;
@@ -41,8 +42,13 @@ import java.util.Set;
 @SequenceGenerator(name = "project_seq", allocationSize = 1)
 @Table(name = "project")
 public class ProjectEntity extends IdEntity
-        implements HibernateRelations.HasId, HibernateRelations.HasName, HibernateRelations.HasDescription,
-        HibernateRelations.HasAbstractDatasets, HibernateRelations.HasStaIdentifier, HibernateRelations.HasParameters {
+        implements
+        HibernateRelations.HasId,
+        HibernateRelations.HasName,
+        HibernateRelations.HasDescription,
+        HibernateRelations.HasAbstractDatasets,
+        HibernateRelations.HasStaIdentifier,
+        HibernateRelations.HasParameters {
 
     public static final String PROPERTY_DATASTREAMS = "datasets";
     public static final String PROPERTY_URL = "url";
@@ -92,7 +98,7 @@ public class ProjectEntity extends IdEntity
     private Set<AbstractDatasetEntity> datasets;
 
     @OneToMany(mappedBy = ProjectParameterEntity.PROP_PROJECT, targetEntity = ProjectParameterEntity.class)
-    private Set<ParameterEntity<?>> parameters;
+    private Set<ParameterEntity< ? >> parameters;
 
     public String getStaIdentifier() {
         return staIdentifier;
@@ -120,26 +126,26 @@ public class ProjectEntity extends IdEntity
 
     public Date getRuntimeStart() {
         return runtimeStart != null
-        		? new Date(runtimeStart.getTime())
-				: null;
+                ? new Date(runtimeStart.getTime())
+                : null;
     }
 
     public void setRuntimeStart(Date runtimeStart) {
         this.runtimeStart = runtimeStart != null
-        		? new Date(runtimeStart.getTime())
-				: null;
+                ? new Date(runtimeStart.getTime())
+                : null;
     }
 
     public Date getRuntimeEnd() {
         return runtimeEnd != null
-        		? new Date(runtimeEnd.getTime())
-				: null;
+                ? new Date(runtimeEnd.getTime())
+                : null;
     }
 
     public void setRuntimeEnd(Date runtimeEnd) {
         this.runtimeEnd = runtimeEnd != null
-        		? new Date(runtimeEnd.getTime())
-        		: null;
+                ? new Date(runtimeEnd.getTime())
+                : null;
     }
 
     public String getUrl() {
@@ -185,17 +191,17 @@ public class ProjectEntity extends IdEntity
     }
 
     @Override
-    public Set<ParameterEntity<?>> getParameters() {
+    public Set<ParameterEntity< ? >> getParameters() {
         return parameters;
     }
 
     @Override
-    public void setParameters(Set<ParameterEntity<?>> parameters) {
+    public void setParameters(Set<ParameterEntity< ? >> parameters) {
         this.parameters = parameters;
     }
 
     @Override
-    public void addParameters(Set<ParameterEntity<?>> parameters) {
+    public void addParameters(Set<ParameterEntity< ? >> parameters) {
         if (this.parameters == null) {
             this.parameters = new HashSet<>();
         }
@@ -203,7 +209,7 @@ public class ProjectEntity extends IdEntity
     }
 
     @Override
-    public void addParameter(ParameterEntity<?> parameter) {
+    public void addParameter(ParameterEntity< ? > parameter) {
         if (this.parameters == null) {
             this.parameters = new HashSet<>();
         }


### PR DESCRIPTION
CitSci Entities has to inherit from IdEntity so that they can be cast correctly by CudRequestHandler. Otherwise the entity might have been persisted correctly but the reponse results in a HTTP 500 error (ClassCastException) and clients are not able to work with the response.